### PR TITLE
updated tagline and updated links in about us

### DIFF
--- a/src/main/resources/static/css/about-us.css
+++ b/src/main/resources/static/css/about-us.css
@@ -26,6 +26,7 @@ nav {
     color: #000000;
     font-size: 58px;
     text-align: center;
+
 }
 
 h5 {
@@ -36,6 +37,7 @@ h5 {
 h4 {
     text-shadow: 0px .3px lightgray;
     font-size: 40px;
+
 }
 
 li {

--- a/src/main/resources/templates/about-us.html
+++ b/src/main/resources/templates/about-us.html
@@ -52,7 +52,7 @@
 <div class="container ">
     <ul class="row justify-content-center">
         <li class="col-12 col-sm-6 col-md-6 col-lg-3">
-            <div class="card-group">
+            <div class="card-group animated fadeInUp">
                 <div class="card contT">
                     <div class="card-header">
                         <h4>Stephen</h4>
@@ -61,15 +61,15 @@
                     <img src="img/StephenApolinar.jpg" class=" card-img-top"/>
                     <div class="cont card-body">
                         <a href="https://www.linkedin.com/in/stephen-apolinar/"
-                           class="fa icon fa-linkedin rounded-circle"></a>
-                        <a href="https://github.com/stephen-apolinar" class="fa fa-github rounded-circle"></a>
+                           class="fa icon fa-linkedin rounded-circle" target="_blank"></a>
+                        <a href="https://github.com/stephen-apolinar" class="fa fa-github rounded-circle" target="_blank"></a>
                     </div>
                 </div>
             </div>
         </li>
         <li class="col-12 col-sm-6 col-md-6 col-lg-3">
 
-            <div class="card-group">
+            <div class="card-group animated fadeInUp">
                 <div class="card contT">
                     <div class="card-header">
                         <h4>Justin</h4>
@@ -77,14 +77,14 @@
                     </div>
                     <img src="img/JustinRihn.jpg" class="card-img-top"/>
                     <div class="cont card-body">
-                            <a href="https://www.linkedin.com/in/justin-rihn" class="fa icon rounded-circle fa-linkedin"></a>
-                            <a href="https://github.com/JRihn32" class="fa rounded-circle fa-github"></a>
+                            <a href="https://www.linkedin.com/in/justin-rihn" class="fa icon rounded-circle fa-linkedin" target="_blank"></a>
+                            <a href="https://github.com/JRihn32" class="fa rounded-circle fa-github" target="_blank"></a>
                     </div>
                 </div>
             </div>
         </li>
         <li class="col-12 col-sm-6 col-md-6 col-lg-3">
-            <div class="card-group">
+            <div class="card-group animated fadeInUp">
                 <div class="card contT">
                     <div class="card-header">
                         <h4>Linda</h4>
@@ -93,14 +93,14 @@
                     <img src="img/LindaHerrera.jpg" class=" card-img-top"/>
                     <div class="cont card-body">
                         <a href="https://www.linkedin.com/in/linda-herrera"
-                           class="fa icon fa-linkedin rounded-circle"></a>
-                        <a href="https://github.com/LindaHerrera" class="fa fa-github rounded-circle"></a>
+                           class="fa icon fa-linkedin rounded-circle" target="_blank"></a>
+                        <a href="https://github.com/LindaHerrera" class="fa fa-github rounded-circle" target="_blank"></a>
                     </div>
                 </div>
             </div>
         </li>
         <li class="col-12 col-sm-6 col-md-6 col-lg-3">
-            <div class="card-group">
+            <div class="card-group animated fadeInUp">
                 <div class="card contT">
                     <div class="card-header">
                         <h4>Armando</h4>
@@ -109,8 +109,8 @@
                     <img src="img/ArmandoSifuentes.jpg" class=" card-img-top"/>
                     <div class="cont card-body">
                         <a href="https://www.linkedin.com/in/armando-sifuentes"
-                           class="fa icon fa-linkedin rounded-circle"></a>
-                        <a href="https://github.com/Mando72" class="fa fa-github rounded-circle"></a>
+                           class="fa icon fa-linkedin rounded-circle" target="_blank"></a>
+                        <a href="https://github.com/Mando72" class="fa fa-github rounded-circle" target="_blank"></a>
                     </div>
                 </div>
             </div>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -13,7 +13,7 @@
     <hr class="line"/>
 
     <div class="home-text2">
-        <p class="animated fadeInUp">Task manager for the busiest</p>
+        <p class="animated fadeInUp">Task manager for the agile workplace</p>
     </div>
 </div>
 


### PR DESCRIPTION
changed tagline from "Task manager for the busiest" to "Task manager for the agile workplace"
external links in about us page will now open in new tabs instead of redirecting the current page